### PR TITLE
Fix: Configure Traefik for Frontend-Backend Communication

### DIFF
--- a/traefik/dynamic/dynamic.yml
+++ b/traefik/dynamic/dynamic.yml
@@ -8,6 +8,17 @@ http:
       tls:
         certResolver: letsencrypt
 
+    backend-api:
+      rule: "Host(`app.crm-synergy.ru`) && PathPrefix(`/api`)"
+      entryPoints:
+        - websecure
+      service: backend
+      tls:
+        certResolver: letsencrypt
+      middlewares:
+        - api-stripprefix
+      priority: 10
+
     backend:
       rule: "Host(`api.crm-synergy.ru`)"
       entryPoints:
@@ -65,3 +76,9 @@ http:
       loadBalancer:
         servers:
           - url: "http://telegram-service:8082"
+
+  middlewares:
+    api-stripprefix:
+      stripPrefix:
+        prefixes:
+          - "/api"


### PR DESCRIPTION
This change updates the Traefik routing configuration to correctly handle API requests from the frontend.

Previously, the frontend, served at `app.crm-synergy.ru`, made API requests to relative paths like `/api`. These requests were not correctly routed to the backend service, leading to communication failures.

This change introduces a new Traefik router that specifically handles requests to `app.crm-synergy.ru/api`. It forwards these requests to the backend service and uses a middleware to strip the `/api` prefix, ensuring the backend receives the request at the expected path. This resolves the frontend-backend connectivity issue without requiring changes to the application code.