### PR TITLE
Fix Traefik routing for backend API

### DIFF
--- a/traefik/dynamic/dynamic.yml
+++ b/traefik/dynamic/dynamic.yml
@@ -15,8 +15,6 @@ http:
       service: backend
       tls:
         certResolver: letsencrypt
-      middlewares:
-        - api-stripprefix
       priority: 10
 
     backend:
@@ -78,9 +76,5 @@ http:
         servers:
           - url: "http://telegram-service:8082"
 
-  middlewares:
-    api-stripprefix:
-      stripPrefix:
-        prefixes:
-          - "/api"
+# Removed strip prefix middleware to keep `/api` segment for backend routes
 # End of file


### PR DESCRIPTION
## Summary
- remove the strip-prefix middleware from the Traefik router that handles /api requests for the frontend host
- ensure backend requests keep the /api segment so Spring controllers mapped to /api/** are reachable

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68ca6433acec8326b446033d853d0390