### PR TITLE
Fix Traefik routing for backend API

### DIFF
--- a/crm-system/src/main/java/com/crm/system/controller/AuthController.java
+++ b/crm-system/src/main/java/com/crm/system/controller/AuthController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api")
 public class AuthController {
     private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
 
@@ -41,7 +41,7 @@ public class AuthController {
         this.jwtTokenUtil = jwtTokenUtil;
     }
 
-    @PostMapping({"/signin", "/login"})
+    @PostMapping({"/auth/signin", "/auth/login", "/login"})
     public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginDto loginDto) {
         logger.info("Authentication attempt for email: {}", loginDto.getEmail());
 
@@ -72,13 +72,13 @@ public class AuthController {
         }
     }
 
-    @PostMapping("/logout")
+    @PostMapping("/auth/logout")
     public ResponseEntity<MessageDto> logout() {
         SecurityContextHolder.clearContext();
         return ResponseEntity.ok(new MessageDto("Logout successful"));
     }
 
-    @PostMapping("/refresh")
+    @PostMapping("/auth/refresh")
     public ResponseEntity<?> refreshToken(Authentication authentication) {
         if (authentication == null || !authentication.isAuthenticated()) {
             return ResponseEntity.status(401).body(new MessageDto("Error: Unauthorized"));
@@ -90,13 +90,13 @@ public class AuthController {
                 "expiresIn", jwtTokenUtil.getExpirationSeconds()));
     }
 
-    @GetMapping("/validate")
+    @GetMapping("/auth/validate")
     public ResponseEntity<?> validateToken(Authentication authentication) {
         boolean valid = authentication != null && authentication.isAuthenticated();
         return ResponseEntity.ok(Map.of("valid", valid));
     }
 
-    @PostMapping("/signup")
+    @PostMapping("/auth/signup")
     public ResponseEntity<?> registerUser(@Valid @RequestBody SignupDto signUpDto) {
         logger.info("Signup attempt for email: {}", signUpDto.getEmail());
 
@@ -123,13 +123,13 @@ public class AuthController {
         }
     }
 
-    @GetMapping("/test")
+    @GetMapping("/auth/test")
     public ResponseEntity<?> testEndpoint() {
         logger.info("Test endpoint called");
         return ResponseEntity.ok("Test endpoint works!");
     }
 
-    @GetMapping("/public")
+    @GetMapping("/auth/public")
     public ResponseEntity<String> publicEndpoint() {
         logger.info("Public endpoint called");
         return ResponseEntity.ok("Public endpoint works!");

--- a/crm-system/src/main/java/com/crm/system/security/WebSecurityConfig.java
+++ b/crm-system/src/main/java/com/crm/system/security/WebSecurityConfig.java
@@ -49,7 +49,7 @@ public class WebSecurityConfig {
             .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/auth/**", "/actuator/**", "/error", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                    .requestMatchers("/api/auth/**", "/api/login", "/actuator/**", "/error", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                     .anyRequest().authenticated()
             );
 

--- a/traefik/dynamic/dynamic.yml
+++ b/traefik/dynamic/dynamic.yml
@@ -15,8 +15,6 @@ http:
       service: backend
       tls:
         certResolver: letsencrypt
-      middlewares:
-        - api-stripprefix
       priority: 10
 
     backend:
@@ -78,9 +76,5 @@ http:
         servers:
           - url: "http://telegram-service:8082"
 
-  middlewares:
-    api-stripprefix:
-      stripPrefix:
-        prefixes:
-          - "/api"
+# Removed strip prefix middleware to keep `/api` segment for backend routes
 # End of file


### PR DESCRIPTION
## Summary
- remove the strip-prefix middleware from the Traefik router that handles /api requests for the frontend host
- ensure backend requests keep the /api segment so Spring controllers mapped to /api/** are reachable
- expose `/api/login` alongside the existing `/api/auth/login` endpoint and whitelist it in security so the frontend login form succeeds

## Testing
- `mvn -q -DskipTests package` *(fails: cannot reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6433acec8326b446033d853d0390